### PR TITLE
feat(extends): remove group:allNonMajor

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
     ":preserveSemverRanges",
     ":prHourlyLimit4",
     ":semanticCommits",
-    "group:allNonMajor",
     "group:monorepos",
     "group:recommended",
     ":timezone(Europe/Paris)",


### PR DESCRIPTION
<img src="https://media.giphy.com/media/pIMlKqgdZgvo4/giphy.gif" width=693>

---

Looking at what this rule is doing I would argue that it's preferable to activate it per project that cross project. As this rule force all non major dependencies to be in the same commit/pr, we have as a result failing PR caused by one or two unmergeable dependencies. I think any mergeable dependency update should be merge. For this having a separated commit for paths and minors helps by atomically merging what can be merged.
In addition, even if the commit/pr didn't fail our tests, we can still have regression. I do think that it's better to be able to revert a single broken dependency that all the updates at once.
Finally some dependencies are linked (through peer dependencies for example) and might be easier to update separately than in batch.