### PR TITLE
fix: more custom

### DIFF
--- a/light.json
+++ b/light.json
@@ -1,16 +1,21 @@
 {
+  "enabled": true,
   "extends": [
-    "config:semverAllMonthly",
+    ":preserveSemverRanges",
+    "schedule:monthly",
+    ":maintainLockFilesMonthly",
     ":masterIssue",
     ":semanticCommits",
     ":timezone(Europe/Paris)",
-    "group:allNonMajor"
+    "group:allNonMajor",
+    "group:recommended",
+    ":separateMajorReleases"
   ],
   "masterIssueAutoclose": true,
   "separateMinorPatch": true,
   "patch": {
     "automerge": true,
-    "extends": ["schedule:earlyMondays"]
+    "extends": ["schedule:earlyMondays", "group:all"]
   },
   "node": {
     "supportPolicy": ["lts_latest"]
@@ -18,24 +23,21 @@
   "packageRules": [
     {
       "groupName": "SocialGouv",
-      "packagePatterns": [
-        "^@socialgouv/"
-      ]
+      "packagePatterns": ["^@socialgouv/"]
     },
     {
-      "datasources": [
-        "docker"
-      ],
+      "datasources": ["docker"],
       "packagePatterns": [
         "^registry.gitlab.factory.social.gouv.fr/socialgouv/docker/"
       ],
       "groupName": "socialgouv/docker images"
     }
   ],
-  "postUpdateOptions": [
-    "npmDedupe", 
-    "yarnDedupeHighest"
-  ],
+  "postUpdateOptions": ["npmDedupe", "yarnDedupeHighest"],
   "rangeStrategy": "bump",
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "extends": ["group:all"],
+    "commitMessageAction": "Update"
+  }
 }

--- a/light.json
+++ b/light.json
@@ -3,13 +3,14 @@
     "config:semverAllMonthly",
     ":masterIssue",
     ":semanticCommits",
-    ":timezone(Europe/Paris)"
+    ":timezone(Europe/Paris)",
+    "group:allNonMajor"
   ],
   "masterIssueAutoclose": true,
   "separateMinorPatch": true,
   "patch": {
     "automerge": true,
-    "schedule": ["earlyMondays"]
+    "extends": ["schedule:earlyMondays"]
   },
   "node": {
     "supportPolicy": ["lts_latest"]


### PR DESCRIPTION
Au final :

 - patchs appliqués en groupe toutes les semaines automagiquement
 - mineurs mensuellement via une PR groupée
 - majors séparées mensuellement

est-ce que ca vous parait un "sane default" ?

la [master issue](https://github.com/SocialGouv/test-renovate/issues/2) c'est hyper bien ca permet de voir les changes et d'anticiper

repo de test : https://github.com/SocialGouv/renovate-config

Je rajoute une petite doc sur le support asap

<img width="551" alt="Capture d’écran 2020-05-20 à 00 03 37" src="https://user-images.githubusercontent.com/124937/82383244-b3dc8180-9a2d-11ea-984a-aecb04c444ef.png">
