### PR TITLE
feat: add stabilityDays=15

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "stabilityDays": 15,
   "extends": [
     "config:base",
     "docker:enableMajor",


### PR DESCRIPTION
Add 15 [stabilityDays](https://docs.renovatebot.com/configuration-options/#stabilitydays) 

15 days required before a new release is considered to be stabilized.