### PR TITLE
fix: docker default renovation

### DIFF
--- a/default.json
+++ b/default.json
@@ -32,10 +32,10 @@
       "groupName": "socialgouv/docker images",
       "matchDatasources": ["docker"],
       "matchPackagePatterns": [
-        "^registry.gitlab.factory.social.gouv.fr/socialgouv/docker/",
-        "^ghcr.io/socialgouv/docker/",
-        "^docker.pkg.github.com/socialgouv/docker/"
-      ]
+        "^ghcr.io/socialgouv/",
+        "^harbor.fabrique.social.gouv.fr/"
+      ],
+      "semanticCommitType": "fix"
     }
   ],
 


### PR DESCRIPTION
For socialgouv images :
 - add harbor source
 - set semanticCommitType to `fix`